### PR TITLE
lib/ynl: reject strings with 0 len in ynl_attr_validate()

### DIFF
--- a/lib/ynl.c
+++ b/lib/ynl.c
@@ -426,7 +426,7 @@ int ynl_attr_validate(struct ynl_parse_arg* yarg, const struct nlattr* attr) {
           policy->name);
       return -1;
     case YNL_PT_NUL_STR:
-      if ((!policy->len || len <= policy->len) && !data[len - 1])
+      if (len && (!policy->len || len <= policy->len) && !data[len - 1])
         break;
       yerr(
           yarg->ys,


### PR DESCRIPTION
Strings from kernel are always null terminated which is checked for but it currently assumes that the len is > 0. Check that this is true before trying to access the char at (len - 1).