### PR TITLE
Fix a memory leak issue with ynl

### DIFF
--- a/generated/ethtool-user.cpp
+++ b/generated/ethtool-user.cpp
@@ -7,13 +7,8 @@
 
 #include <array>
 
+#include <linux/ethtool.h>
 #include <linux/ethtool_netlink_generated.h>
-#include <linux/ethtool.h>
-#include <linux/ethtool.h>
-#include <linux/ethtool.h>
-#include <linux/ethtool.h>
-#include <linux/ethtool.h>
-#include <linux/ethtool.h>
 
 #include <linux/genetlink.h>
 
@@ -2433,7 +2428,7 @@ int ethtool_cable_nest_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_cable_result_nest;
-			parg.data = &dst->result;
+			parg.data = &dst->result.emplace();
 			if (ethtool_cable_result_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_CABLE_NEST_FAULT_LENGTH) {
@@ -2441,7 +2436,7 @@ int ethtool_cable_nest_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_cable_fault_length_nest;
-			parg.data = &dst->fault_length;
+			parg.data = &dst->fault_length.emplace();
 			if (ethtool_cable_fault_length_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -2479,7 +2474,7 @@ int ethtool_stats_grp_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_stats_grp_hist_nest;
-			parg.data = &dst->hist_rx;
+			parg.data = &dst->hist_rx.emplace();
 			if (ethtool_stats_grp_hist_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_STATS_GRP_HIST_TX) {
@@ -2487,7 +2482,7 @@ int ethtool_stats_grp_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_stats_grp_hist_nest;
-			parg.data = &dst->hist_tx;
+			parg.data = &dst->hist_tx.emplace();
 			if (ethtool_stats_grp_hist_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_STATS_GRP_HIST_BKT_LOW) {
@@ -2657,7 +2652,7 @@ int ethtool_bitset_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_bits_nest;
-			parg.data = &dst->bits;
+			parg.data = &dst->bits.emplace();
 			if (ethtool_bitset_bits_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_BITSET_VALUE) {
@@ -2768,7 +2763,7 @@ int ethtool_tunnel_udp_table_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->types;
+			parg.data = &dst->types.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_TUNNEL_UDP_TABLE_ENTRY) {
@@ -2862,7 +2857,7 @@ int ethtool_tunnel_udp_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_tunnel_udp_table_nest;
-			parg.data = &dst->table;
+			parg.data = &dst->table.emplace();
 			if (ethtool_tunnel_udp_table_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -2891,7 +2886,7 @@ int ethtool_strset_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_STRSET_STRINGSETS) {
@@ -2899,7 +2894,7 @@ int ethtool_strset_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_stringsets_nest;
-			parg.data = &dst->stringsets;
+			parg.data = &dst->stringsets.emplace();
 			if (ethtool_stringsets_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -2993,7 +2988,7 @@ int ethtool_linkinfo_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_LINKINFO_PORT) {
@@ -3132,7 +3127,7 @@ int ethtool_linkmodes_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_LINKMODES_AUTONEG) {
@@ -3144,7 +3139,7 @@ int ethtool_linkmodes_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->ours;
+			parg.data = &dst->ours.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_LINKMODES_PEER) {
@@ -3152,7 +3147,7 @@ int ethtool_linkmodes_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->peer;
+			parg.data = &dst->peer.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_LINKMODES_SPEED) {
@@ -3303,7 +3298,7 @@ int ethtool_linkstate_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_LINKSTATE_LINK) {
@@ -3413,7 +3408,7 @@ int ethtool_debug_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_DEBUG_MSGMASK) {
@@ -3421,7 +3416,7 @@ int ethtool_debug_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->msgmask;
+			parg.data = &dst->msgmask.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -3531,7 +3526,7 @@ int ethtool_wol_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_WOL_MODES) {
@@ -3539,7 +3534,7 @@ int ethtool_wol_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->modes;
+			parg.data = &dst->modes.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_WOL_SOPASS) {
@@ -3656,7 +3651,7 @@ int ethtool_features_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_FEATURES_HW) {
@@ -3664,7 +3659,7 @@ int ethtool_features_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->hw;
+			parg.data = &dst->hw.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_FEATURES_WANTED) {
@@ -3672,7 +3667,7 @@ int ethtool_features_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->wanted;
+			parg.data = &dst->wanted.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_FEATURES_ACTIVE) {
@@ -3680,7 +3675,7 @@ int ethtool_features_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->active;
+			parg.data = &dst->active.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_FEATURES_NOCHANGE) {
@@ -3688,7 +3683,7 @@ int ethtool_features_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->nochange;
+			parg.data = &dst->nochange.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -3775,7 +3770,7 @@ int ethtool_features_set_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_FEATURES_HW) {
@@ -3783,7 +3778,7 @@ int ethtool_features_set_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->hw;
+			parg.data = &dst->hw.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_FEATURES_WANTED) {
@@ -3791,7 +3786,7 @@ int ethtool_features_set_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->wanted;
+			parg.data = &dst->wanted.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_FEATURES_ACTIVE) {
@@ -3799,7 +3794,7 @@ int ethtool_features_set_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->active;
+			parg.data = &dst->active.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_FEATURES_NOCHANGE) {
@@ -3807,7 +3802,7 @@ int ethtool_features_set_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->nochange;
+			parg.data = &dst->nochange.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -3871,7 +3866,7 @@ int ethtool_privflags_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_PRIVFLAGS_FLAGS) {
@@ -3879,7 +3874,7 @@ int ethtool_privflags_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->flags;
+			parg.data = &dst->flags.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -3990,7 +3985,7 @@ int ethtool_rings_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_RINGS_RX_MAX) {
@@ -4200,7 +4195,7 @@ int ethtool_channels_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_CHANNELS_RX_MAX) {
@@ -4357,7 +4352,7 @@ int ethtool_coalesce_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_COALESCE_RX_USECS) {
@@ -4473,7 +4468,7 @@ int ethtool_coalesce_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_profile_nest;
-			parg.data = &dst->rx_profile;
+			parg.data = &dst->rx_profile.emplace();
 			if (ethtool_profile_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_COALESCE_TX_PROFILE) {
@@ -4481,7 +4476,7 @@ int ethtool_coalesce_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_profile_nest;
-			parg.data = &dst->tx_profile;
+			parg.data = &dst->tx_profile.emplace();
 			if (ethtool_profile_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -4648,7 +4643,7 @@ int ethtool_pause_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_PAUSE_AUTONEG) {
@@ -4668,7 +4663,7 @@ int ethtool_pause_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_pause_stat_nest;
-			parg.data = &dst->stats;
+			parg.data = &dst->stats.emplace();
 			if (ethtool_pause_stat_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_PAUSE_STATS_SRC) {
@@ -4790,7 +4785,7 @@ int ethtool_eee_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_EEE_MODES_OURS) {
@@ -4798,7 +4793,7 @@ int ethtool_eee_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->modes_ours;
+			parg.data = &dst->modes_ours.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_EEE_MODES_PEER) {
@@ -4806,7 +4801,7 @@ int ethtool_eee_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->modes_peer;
+			parg.data = &dst->modes_peer.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_EEE_ACTIVE) {
@@ -4941,7 +4936,7 @@ int ethtool_tsinfo_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_TSINFO_TIMESTAMPING) {
@@ -4949,7 +4944,7 @@ int ethtool_tsinfo_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->timestamping;
+			parg.data = &dst->timestamping.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_TSINFO_TX_TYPES) {
@@ -4957,7 +4952,7 @@ int ethtool_tsinfo_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->tx_types;
+			parg.data = &dst->tx_types.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_TSINFO_RX_FILTERS) {
@@ -4965,7 +4960,7 @@ int ethtool_tsinfo_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->rx_filters;
+			parg.data = &dst->rx_filters.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_TSINFO_PHC_INDEX) {
@@ -4977,7 +4972,7 @@ int ethtool_tsinfo_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_ts_stat_nest;
-			parg.data = &dst->stats;
+			parg.data = &dst->stats.emplace();
 			if (ethtool_ts_stat_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_TSINFO_HWTSTAMP_PROVIDER) {
@@ -4985,7 +4980,7 @@ int ethtool_tsinfo_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_ts_hwtstamp_provider_nest;
-			parg.data = &dst->hwtstamp_provider;
+			parg.data = &dst->hwtstamp_provider.emplace();
 			if (ethtool_ts_hwtstamp_provider_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_TSINFO_HWTSTAMP_SOURCE) {
@@ -5127,7 +5122,7 @@ int ethtool_tunnel_info_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_TUNNEL_INFO_UDP_PORTS) {
@@ -5135,7 +5130,7 @@ int ethtool_tunnel_info_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_tunnel_udp_nest;
-			parg.data = &dst->udp_ports;
+			parg.data = &dst->udp_ports.emplace();
 			if (ethtool_tunnel_udp_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -5222,7 +5217,7 @@ int ethtool_fec_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_FEC_MODES) {
@@ -5230,7 +5225,7 @@ int ethtool_fec_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->modes;
+			parg.data = &dst->modes.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_FEC_AUTO) {
@@ -5246,7 +5241,7 @@ int ethtool_fec_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_fec_stat_nest;
-			parg.data = &dst->stats;
+			parg.data = &dst->stats.emplace();
 			if (ethtool_fec_stat_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -5361,7 +5356,7 @@ int ethtool_module_eeprom_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_MODULE_EEPROM_DATA) {
@@ -5474,7 +5469,7 @@ int ethtool_stats_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_STATS_GROUPS) {
@@ -5482,7 +5477,7 @@ int ethtool_stats_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->groups;
+			parg.data = &dst->groups.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_STATS_GRP) {
@@ -5490,7 +5485,7 @@ int ethtool_stats_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_stats_grp_nest;
-			parg.data = &dst->grp;
+			parg.data = &dst->grp.emplace();
 			if (ethtool_stats_grp_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_STATS_SRC) {
@@ -5584,7 +5579,7 @@ int ethtool_phc_vclocks_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_PHC_VCLOCKS_NUM) {
@@ -5675,7 +5670,7 @@ int ethtool_module_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_MODULE_POWER_MODE_POLICY) {
@@ -5800,7 +5795,7 @@ int ethtool_pse_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_PODL_PSE_ADMIN_STATE) {
@@ -5986,7 +5981,7 @@ int ethtool_rss_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_RSS_CONTEXT) {
@@ -6018,7 +6013,7 @@ int ethtool_rss_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_flow_nest;
-			parg.data = &dst->flow_hash;
+			parg.data = &dst->flow_hash.emplace();
 			if (ethtool_flow_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -6108,7 +6103,7 @@ int ethtool_plca_get_cfg_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_PLCA_VERSION) {
@@ -6265,7 +6260,7 @@ int ethtool_plca_get_status_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_PLCA_VERSION) {
@@ -6384,7 +6379,7 @@ int ethtool_mm_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_MM_PMAC_ENABLED) {
@@ -6424,7 +6419,7 @@ int ethtool_mm_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_mm_stat_nest;
-			parg.data = &dst->stats;
+			parg.data = &dst->stats.emplace();
 			if (ethtool_mm_stat_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -6567,7 +6562,7 @@ int ethtool_phy_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_PHY_INDEX) {
@@ -6681,7 +6676,7 @@ int ethtool_tsconfig_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_TSCONFIG_HWTSTAMP_PROVIDER) {
@@ -6689,7 +6684,7 @@ int ethtool_tsconfig_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_ts_hwtstamp_provider_nest;
-			parg.data = &dst->hwtstamp_provider;
+			parg.data = &dst->hwtstamp_provider.emplace();
 			if (ethtool_ts_hwtstamp_provider_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_TSCONFIG_TX_TYPES) {
@@ -6697,7 +6692,7 @@ int ethtool_tsconfig_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->tx_types;
+			parg.data = &dst->tx_types.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_TSCONFIG_RX_FILTERS) {
@@ -6705,7 +6700,7 @@ int ethtool_tsconfig_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->rx_filters;
+			parg.data = &dst->rx_filters.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_TSCONFIG_HWTSTAMP_FLAGS) {
@@ -6713,7 +6708,7 @@ int ethtool_tsconfig_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->hwtstamp_flags;
+			parg.data = &dst->hwtstamp_flags.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -6799,7 +6794,7 @@ int ethtool_tsconfig_set_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_TSCONFIG_HWTSTAMP_PROVIDER) {
@@ -6807,7 +6802,7 @@ int ethtool_tsconfig_set_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_ts_hwtstamp_provider_nest;
-			parg.data = &dst->hwtstamp_provider;
+			parg.data = &dst->hwtstamp_provider.emplace();
 			if (ethtool_ts_hwtstamp_provider_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_TSCONFIG_TX_TYPES) {
@@ -6815,7 +6810,7 @@ int ethtool_tsconfig_set_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->tx_types;
+			parg.data = &dst->tx_types.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_TSCONFIG_RX_FILTERS) {
@@ -6823,7 +6818,7 @@ int ethtool_tsconfig_set_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->rx_filters;
+			parg.data = &dst->rx_filters.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_TSCONFIG_HWTSTAMP_FLAGS) {
@@ -6831,7 +6826,7 @@ int ethtool_tsconfig_set_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_bitset_nest;
-			parg.data = &dst->hwtstamp_flags;
+			parg.data = &dst->hwtstamp_flags.emplace();
 			if (ethtool_bitset_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -6928,7 +6923,7 @@ int ethtool_rss_create_act_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_RSS_CONTEXT) {
@@ -7043,7 +7038,7 @@ int ethtool_cable_test_ntf_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_CABLE_TEST_NTF_STATUS) {
@@ -7075,7 +7070,7 @@ int ethtool_cable_test_tdr_ntf_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_CABLE_TEST_TDR_NTF_STATUS) {
@@ -7087,7 +7082,7 @@ int ethtool_cable_test_tdr_ntf_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_cable_nest_nest;
-			parg.data = &dst->nest;
+			parg.data = &dst->nest.emplace();
 			if (ethtool_cable_nest_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -7115,7 +7110,7 @@ int ethtool_module_fw_flash_ntf_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_MODULE_FW_FLASH_STATUS) {
@@ -7159,7 +7154,7 @@ int ethtool_pse_ntf_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_PSE_NTF_EVENTS) {
@@ -7191,7 +7186,7 @@ int ethtool_rss_delete_ntf_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ethtool_header_nest;
-			parg.data = &dst->header;
+			parg.data = &dst->header.emplace();
 			if (ethtool_header_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == ETHTOOL_A_RSS_CONTEXT) {

--- a/generated/ethtool-user.hpp
+++ b/generated/ethtool-user.hpp
@@ -19,13 +19,8 @@
 
 #include "ynl.hpp"
 
+#include <linux/ethtool.h>
 #include <linux/ethtool_netlink_generated.h>
-#include <linux/ethtool.h>
-#include <linux/ethtool.h>
-#include <linux/ethtool.h>
-#include <linux/ethtool.h>
-#include <linux/ethtool.h>
-#include <linux/ethtool.h>
 
 namespace ynl_cpp {
 const struct ynl_family& get_ynl_ethtool_family();

--- a/generated/mptcp_pm-user.cpp
+++ b/generated/mptcp_pm-user.cpp
@@ -259,7 +259,7 @@ int mptcp_pm_get_addr_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &mptcp_pm_address_nest;
-			parg.data = &dst->addr;
+			parg.data = &dst->addr.emplace();
 			if (mptcp_pm_address_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}

--- a/generated/net_shaper-user.cpp
+++ b/generated/net_shaper-user.cpp
@@ -236,7 +236,7 @@ int net_shaper_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &net_shaper_handle_nest;
-			parg.data = &dst->parent;
+			parg.data = &dst->parent.emplace();
 			if (net_shaper_handle_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NET_SHAPER_A_HANDLE) {
@@ -244,7 +244,7 @@ int net_shaper_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &net_shaper_handle_nest;
-			parg.data = &dst->handle;
+			parg.data = &dst->handle.emplace();
 			if (net_shaper_handle_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NET_SHAPER_A_METRIC) {
@@ -417,7 +417,7 @@ int net_shaper_group_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &net_shaper_handle_nest;
-			parg.data = &dst->handle;
+			parg.data = &dst->handle.emplace();
 			if (net_shaper_handle_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}

--- a/generated/netdev-user.cpp
+++ b/generated/netdev-user.cpp
@@ -631,7 +631,7 @@ int netdev_page_pool_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &netdev_io_uring_provider_info_nest;
-			parg.data = &dst->io_uring;
+			parg.data = &dst->io_uring.emplace();
 			if (netdev_io_uring_provider_info_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -713,7 +713,7 @@ int netdev_page_pool_stats_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &netdev_page_pool_info_nest;
-			parg.data = &dst->info;
+			parg.data = &dst->info.emplace();
 			if (netdev_page_pool_info_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NETDEV_A_PAGE_POOL_STATS_ALLOC_FAST) {
@@ -859,7 +859,7 @@ int netdev_queue_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &netdev_io_uring_provider_info_nest;
-			parg.data = &dst->io_uring;
+			parg.data = &dst->io_uring.emplace();
 			if (netdev_io_uring_provider_info_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NETDEV_A_QUEUE_XSK) {
@@ -867,7 +867,7 @@ int netdev_queue_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &netdev_xsk_info_nest;
-			parg.data = &dst->xsk;
+			parg.data = &dst->xsk.emplace();
 			if (netdev_xsk_info_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}

--- a/generated/nl80211-user.cpp
+++ b/generated/nl80211-user.cpp
@@ -1645,7 +1645,7 @@ int nl80211_iface_limit_attributes_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_supported_iftypes_nest;
-			parg.data = &dst->types;
+			parg.data = &dst->types.emplace();
 			if (nl80211_supported_iftypes_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -1844,7 +1844,7 @@ int nl80211_iftype_attrs_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_frame_type_attrs_nest;
-			parg.data = &dst->unspecified;
+			parg.data = &dst->unspecified.emplace();
 			if (nl80211_frame_type_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_IFTYPE_ADHOC) {
@@ -1852,7 +1852,7 @@ int nl80211_iftype_attrs_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_frame_type_attrs_nest;
-			parg.data = &dst->adhoc;
+			parg.data = &dst->adhoc.emplace();
 			if (nl80211_frame_type_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_IFTYPE_STATION) {
@@ -1860,7 +1860,7 @@ int nl80211_iftype_attrs_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_frame_type_attrs_nest;
-			parg.data = &dst->station;
+			parg.data = &dst->station.emplace();
 			if (nl80211_frame_type_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_IFTYPE_AP) {
@@ -1868,7 +1868,7 @@ int nl80211_iftype_attrs_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_frame_type_attrs_nest;
-			parg.data = &dst->ap;
+			parg.data = &dst->ap.emplace();
 			if (nl80211_frame_type_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_IFTYPE_AP_VLAN) {
@@ -1876,7 +1876,7 @@ int nl80211_iftype_attrs_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_frame_type_attrs_nest;
-			parg.data = &dst->ap_vlan;
+			parg.data = &dst->ap_vlan.emplace();
 			if (nl80211_frame_type_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_IFTYPE_WDS) {
@@ -1884,7 +1884,7 @@ int nl80211_iftype_attrs_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_frame_type_attrs_nest;
-			parg.data = &dst->wds;
+			parg.data = &dst->wds.emplace();
 			if (nl80211_frame_type_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_IFTYPE_MONITOR) {
@@ -1892,7 +1892,7 @@ int nl80211_iftype_attrs_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_frame_type_attrs_nest;
-			parg.data = &dst->monitor;
+			parg.data = &dst->monitor.emplace();
 			if (nl80211_frame_type_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_IFTYPE_MESH_POINT) {
@@ -1900,7 +1900,7 @@ int nl80211_iftype_attrs_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_frame_type_attrs_nest;
-			parg.data = &dst->mesh_point;
+			parg.data = &dst->mesh_point.emplace();
 			if (nl80211_frame_type_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_IFTYPE_P2P_CLIENT) {
@@ -1908,7 +1908,7 @@ int nl80211_iftype_attrs_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_frame_type_attrs_nest;
-			parg.data = &dst->p2p_client;
+			parg.data = &dst->p2p_client.emplace();
 			if (nl80211_frame_type_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_IFTYPE_P2P_GO) {
@@ -1916,7 +1916,7 @@ int nl80211_iftype_attrs_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_frame_type_attrs_nest;
-			parg.data = &dst->p2p_go;
+			parg.data = &dst->p2p_go.emplace();
 			if (nl80211_frame_type_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_IFTYPE_P2P_DEVICE) {
@@ -1924,7 +1924,7 @@ int nl80211_iftype_attrs_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_frame_type_attrs_nest;
-			parg.data = &dst->p2p_device;
+			parg.data = &dst->p2p_device.emplace();
 			if (nl80211_frame_type_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_IFTYPE_OCB) {
@@ -1932,7 +1932,7 @@ int nl80211_iftype_attrs_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_frame_type_attrs_nest;
-			parg.data = &dst->ocb;
+			parg.data = &dst->ocb.emplace();
 			if (nl80211_frame_type_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_IFTYPE_NAN) {
@@ -1940,7 +1940,7 @@ int nl80211_iftype_attrs_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_frame_type_attrs_nest;
-			parg.data = &dst->nan;
+			parg.data = &dst->nan.emplace();
 			if (nl80211_frame_type_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -2418,7 +2418,7 @@ int nl80211_wiphy_bands_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_band_attrs_nest;
-			parg.data = &dst->_2ghz;
+			parg.data = &dst->_2ghz.emplace();
 			if (nl80211_band_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_BAND_5GHZ) {
@@ -2426,7 +2426,7 @@ int nl80211_wiphy_bands_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_band_attrs_nest;
-			parg.data = &dst->_5ghz;
+			parg.data = &dst->_5ghz.emplace();
 			if (nl80211_band_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_BAND_60GHZ) {
@@ -2434,7 +2434,7 @@ int nl80211_wiphy_bands_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_band_attrs_nest;
-			parg.data = &dst->_60ghz;
+			parg.data = &dst->_60ghz.emplace();
 			if (nl80211_band_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_BAND_6GHZ) {
@@ -2442,7 +2442,7 @@ int nl80211_wiphy_bands_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_band_attrs_nest;
-			parg.data = &dst->_6ghz;
+			parg.data = &dst->_6ghz.emplace();
 			if (nl80211_band_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_BAND_S1GHZ) {
@@ -2450,7 +2450,7 @@ int nl80211_wiphy_bands_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_band_attrs_nest;
-			parg.data = &dst->s1ghz;
+			parg.data = &dst->s1ghz.emplace();
 			if (nl80211_band_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_BAND_LC) {
@@ -2458,7 +2458,7 @@ int nl80211_wiphy_bands_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_band_attrs_nest;
-			parg.data = &dst->lc;
+			parg.data = &dst->lc.emplace();
 			if (nl80211_band_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -2605,7 +2605,7 @@ int nl80211_get_wiphy_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_iftype_attrs_nest;
-			parg.data = &dst->rx_frame_types;
+			parg.data = &dst->rx_frame_types.emplace();
 			if (nl80211_iftype_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_ATTR_SAR_SPEC) {
@@ -2613,7 +2613,7 @@ int nl80211_get_wiphy_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_sar_attributes_nest;
-			parg.data = &dst->sar_spec;
+			parg.data = &dst->sar_spec.emplace();
 			if (nl80211_sar_attributes_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_ATTR_SCHED_SCAN_MAX_REQS) {
@@ -2625,7 +2625,7 @@ int nl80211_get_wiphy_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_supported_iftypes_nest;
-			parg.data = &dst->software_iftypes;
+			parg.data = &dst->software_iftypes.emplace();
 			if (nl80211_supported_iftypes_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_ATTR_SUPPORT_AP_UAPSD) {
@@ -2640,7 +2640,7 @@ int nl80211_get_wiphy_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_supported_iftypes_nest;
-			parg.data = &dst->supported_iftypes;
+			parg.data = &dst->supported_iftypes.emplace();
 			if (nl80211_supported_iftypes_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_ATTR_TDLS_EXTERNAL_SETUP) {
@@ -2654,7 +2654,7 @@ int nl80211_get_wiphy_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_iftype_attrs_nest;
-			parg.data = &dst->tx_frame_types;
+			parg.data = &dst->tx_frame_types.emplace();
 			if (nl80211_iftype_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_ATTR_TXQ_LIMIT) {
@@ -2674,7 +2674,7 @@ int nl80211_get_wiphy_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_txq_stats_attrs_nest;
-			parg.data = &dst->txq_stats;
+			parg.data = &dst->txq_stats.emplace();
 			if (nl80211_txq_stats_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_ATTR_VHT_CAPABILITY_MASK) {
@@ -2708,7 +2708,7 @@ int nl80211_get_wiphy_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_wiphy_bands_nest;
-			parg.data = &dst->wiphy_bands;
+			parg.data = &dst->wiphy_bands.emplace();
 			if (nl80211_wiphy_bands_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_ATTR_WIPHY_COVERAGE_CLASS) {
@@ -2740,7 +2740,7 @@ int nl80211_get_wiphy_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_wowlan_triggers_attrs_nest;
-			parg.data = &dst->wowlan_triggers_supported;
+			parg.data = &dst->wowlan_triggers_supported.emplace();
 			if (nl80211_wowlan_triggers_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -2937,7 +2937,7 @@ int nl80211_get_wiphy_rsp_dump_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_iftype_attrs_nest;
-			parg.data = &dst->rx_frame_types;
+			parg.data = &dst->rx_frame_types.emplace();
 			if (nl80211_iftype_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_ATTR_SAR_SPEC) {
@@ -2945,7 +2945,7 @@ int nl80211_get_wiphy_rsp_dump_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_sar_attributes_nest;
-			parg.data = &dst->sar_spec;
+			parg.data = &dst->sar_spec.emplace();
 			if (nl80211_sar_attributes_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_ATTR_SCHED_SCAN_MAX_REQS) {
@@ -2957,7 +2957,7 @@ int nl80211_get_wiphy_rsp_dump_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_supported_iftypes_nest;
-			parg.data = &dst->software_iftypes;
+			parg.data = &dst->software_iftypes.emplace();
 			if (nl80211_supported_iftypes_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_ATTR_SUPPORT_AP_UAPSD) {
@@ -2972,7 +2972,7 @@ int nl80211_get_wiphy_rsp_dump_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_supported_iftypes_nest;
-			parg.data = &dst->supported_iftypes;
+			parg.data = &dst->supported_iftypes.emplace();
 			if (nl80211_supported_iftypes_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_ATTR_TDLS_EXTERNAL_SETUP) {
@@ -2986,7 +2986,7 @@ int nl80211_get_wiphy_rsp_dump_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_iftype_attrs_nest;
-			parg.data = &dst->tx_frame_types;
+			parg.data = &dst->tx_frame_types.emplace();
 			if (nl80211_iftype_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_ATTR_TXQ_LIMIT) {
@@ -3006,7 +3006,7 @@ int nl80211_get_wiphy_rsp_dump_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_txq_stats_attrs_nest;
-			parg.data = &dst->txq_stats;
+			parg.data = &dst->txq_stats.emplace();
 			if (nl80211_txq_stats_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_ATTR_VHT_CAPABILITY_MASK) {
@@ -3040,7 +3040,7 @@ int nl80211_get_wiphy_rsp_dump_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_wiphy_bands_nest;
-			parg.data = &dst->wiphy_bands;
+			parg.data = &dst->wiphy_bands.emplace();
 			if (nl80211_wiphy_bands_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_ATTR_WIPHY_COVERAGE_CLASS) {
@@ -3072,7 +3072,7 @@ int nl80211_get_wiphy_rsp_dump_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_wowlan_triggers_attrs_nest;
-			parg.data = &dst->wowlan_triggers_supported;
+			parg.data = &dst->wowlan_triggers_supported.emplace();
 			if (nl80211_wowlan_triggers_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -3186,7 +3186,7 @@ int nl80211_get_interface_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_txq_stats_attrs_nest;
-			parg.data = &dst->txq_stats;
+			parg.data = &dst->txq_stats.emplace();
 			if (nl80211_txq_stats_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_ATTR_4ADDR) {
@@ -3275,7 +3275,7 @@ int nl80211_get_interface_rsp_dump_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &nl80211_txq_stats_attrs_nest;
-			parg.data = &dst->txq_stats;
+			parg.data = &dst->txq_stats.emplace();
 			if (nl80211_txq_stats_attrs_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == NL80211_ATTR_4ADDR) {

--- a/generated/ovpn-user.cpp
+++ b/generated/ovpn-user.cpp
@@ -551,7 +551,7 @@ int ovpn_keyconf_parse(struct ynl_parse_arg *yarg, const struct nlattr *nested)
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ovpn_keydir_nest;
-			parg.data = &dst->encrypt_dir;
+			parg.data = &dst->encrypt_dir.emplace();
 			if (ovpn_keydir_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == OVPN_A_KEYCONF_DECRYPT_DIR) {
@@ -559,7 +559,7 @@ int ovpn_keyconf_parse(struct ynl_parse_arg *yarg, const struct nlattr *nested)
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ovpn_keydir_nest;
-			parg.data = &dst->decrypt_dir;
+			parg.data = &dst->decrypt_dir.emplace();
 			if (ovpn_keydir_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -634,7 +634,7 @@ int ovpn_peer_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ovpn_peer_nest;
-			parg.data = &dst->peer;
+			parg.data = &dst->peer.emplace();
 			if (ovpn_peer_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -768,7 +768,7 @@ int ovpn_key_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &ovpn_keyconf_nest;
-			parg.data = &dst->keyconf;
+			parg.data = &dst->keyconf.emplace();
 			if (ovpn_keyconf_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}

--- a/generated/psp-user.cpp
+++ b/generated/psp-user.cpp
@@ -382,7 +382,7 @@ int psp_rx_assoc_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &psp_keys_nest;
-			parg.data = &dst->rx_key;
+			parg.data = &dst->rx_key.emplace();
 			if (psp_keys_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}

--- a/generated/tcp_metrics-user.cpp
+++ b/generated/tcp_metrics-user.cpp
@@ -178,7 +178,7 @@ int tcp_metrics_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &tcp_metrics_metrics_nest;
-			parg.data = &dst->vals;
+			parg.data = &dst->vals.emplace();
 			if (tcp_metrics_metrics_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		} else if (type == TCP_METRICS_ATTR_FOPEN_MSS) {

--- a/generated/team-user.cpp
+++ b/generated/team-user.cpp
@@ -265,7 +265,7 @@ int team_item_option_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &team_attr_option_nest;
-			parg.data = &dst->option;
+			parg.data = &dst->option.emplace();
 			if (team_attr_option_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -291,7 +291,7 @@ int team_item_port_parse(struct ynl_parse_arg *yarg,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &team_attr_port_nest;
-			parg.data = &dst->port;
+			parg.data = &dst->port.emplace();
 			if (team_attr_port_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -369,7 +369,7 @@ int team_options_set_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &team_item_option_nest;
-			parg.data = &dst->list_option;
+			parg.data = &dst->list_option.emplace();
 			if (team_item_option_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -431,7 +431,7 @@ int team_options_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &team_item_option_nest;
-			parg.data = &dst->list_option;
+			parg.data = &dst->list_option.emplace();
 			if (team_item_option_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}
@@ -491,7 +491,7 @@ int team_port_list_get_rsp_parse(const struct nlmsghdr *nlh,
 				return YNL_PARSE_CB_ERROR;
 
 			parg.rsp_policy = &team_item_port_nest;
-			parg.data = &dst->list_port;
+			parg.data = &dst->list_port.emplace();
 			if (team_item_port_parse(&parg, attr))
 				return YNL_PARSE_CB_ERROR;
 		}

--- a/ynl-gen-cpp.py
+++ b/ynl-gen-cpp.py
@@ -2267,11 +2267,11 @@ def main():
         cw.nl()
         cw.p("#include <array>")
     cw.nl()
-    headers = [parsed.uapi_header]
+    headers = {parsed.uapi_header}
     for definition in parsed["definitions"]:
         if "header" in definition:
-            headers.append(definition["header"])
-    for one in headers:
+            headers.add(definition["header"])
+    for one in sorted(headers):
         cw.p(f"#include <{one}>")
     cw.nl()
 


### PR DESCRIPTION
std::optional<> cannot be initialized directly by &{var}->{c_name}. adding emplace() fixed the issue.

other lines are automatically linted by vscode.