### PR TITLE
ynl-gen-cpp: fix -Wtautological-compare in enum _str bounds check

### DIFF
--- a/generated/binder-user.cpp
+++ b/generated/binder-user.cpp
@@ -22,7 +22,7 @@ static constexpr std::array<std::string_view, BINDER_CMD_REPORT + 1> binder_op_s
 
 std::string_view binder_op_str(int op)
 {
-	if (op < 0 || op >= (int)(binder_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(binder_op_strmap.size())) {
 		return "";
 	}
 	return binder_op_strmap[op];

--- a/generated/dev-energymodel-user.cpp
+++ b/generated/dev-energymodel-user.cpp
@@ -26,7 +26,7 @@ static constexpr std::array<std::string_view, DEV_ENERGYMODEL_CMD_PERF_DOMAIN_DE
 
 std::string_view dev_energymodel_op_str(int op)
 {
-	if (op < 0 || op >= (int)(dev_energymodel_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(dev_energymodel_op_strmap.size())) {
 		return "";
 	}
 	return dev_energymodel_op_strmap[op];
@@ -42,7 +42,7 @@ std::string_view
 dev_energymodel_perf_state_flags_str(dev_energymodel_perf_state_flags value)
 {
 	value = (dev_energymodel_perf_state_flags)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(dev_energymodel_perf_state_flags_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(dev_energymodel_perf_state_flags_strmap.size())) {
 		return "";
 	}
 	return dev_energymodel_perf_state_flags_strmap[value];
@@ -60,7 +60,7 @@ std::string_view
 dev_energymodel_perf_domain_flags_str(dev_energymodel_perf_domain_flags value)
 {
 	value = (dev_energymodel_perf_domain_flags)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(dev_energymodel_perf_domain_flags_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(dev_energymodel_perf_domain_flags_strmap.size())) {
 		return "";
 	}
 	return dev_energymodel_perf_domain_flags_strmap[value];

--- a/generated/devlink-user.cpp
+++ b/generated/devlink-user.cpp
@@ -47,7 +47,7 @@ static constexpr std::array<std::string_view, DEVLINK_CMD_SELFTESTS_GET + 1> dev
 
 std::string_view devlink_op_str(int op)
 {
-	if (op < 0 || op >= (int)(devlink_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(devlink_op_strmap.size())) {
 		return "";
 	}
 	return devlink_op_strmap[op];
@@ -62,7 +62,7 @@ static constexpr std::array<std::string_view, 1 + 1> devlink_sb_pool_type_strmap
 
 std::string_view devlink_sb_pool_type_str(devlink_sb_pool_type value)
 {
-	if (value < 0 || value >= (int)(devlink_sb_pool_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_sb_pool_type_strmap.size())) {
 		return "";
 	}
 	return devlink_sb_pool_type_strmap[value];
@@ -79,7 +79,7 @@ static constexpr std::array<std::string_view, 3 + 1> devlink_port_type_strmap = 
 
 std::string_view devlink_port_type_str(devlink_port_type value)
 {
-	if (value < 0 || value >= (int)(devlink_port_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_port_type_strmap.size())) {
 		return "";
 	}
 	return devlink_port_type_strmap[value];
@@ -100,7 +100,7 @@ static constexpr std::array<std::string_view, 7 + 1> devlink_port_flavour_strmap
 
 std::string_view devlink_port_flavour_str(devlink_port_flavour value)
 {
-	if (value < 0 || value >= (int)(devlink_port_flavour_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_port_flavour_strmap.size())) {
 		return "";
 	}
 	return devlink_port_flavour_strmap[value];
@@ -115,7 +115,7 @@ static constexpr std::array<std::string_view, 1 + 1> devlink_port_fn_state_strma
 
 std::string_view devlink_port_fn_state_str(devlink_port_fn_state value)
 {
-	if (value < 0 || value >= (int)(devlink_port_fn_state_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_port_fn_state_strmap.size())) {
 		return "";
 	}
 	return devlink_port_fn_state_strmap[value];
@@ -130,7 +130,7 @@ static constexpr std::array<std::string_view, 1 + 1> devlink_port_fn_opstate_str
 
 std::string_view devlink_port_fn_opstate_str(devlink_port_fn_opstate value)
 {
-	if (value < 0 || value >= (int)(devlink_port_fn_opstate_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_port_fn_opstate_strmap.size())) {
 		return "";
 	}
 	return devlink_port_fn_opstate_strmap[value];
@@ -147,7 +147,7 @@ static constexpr std::array<std::string_view, 3 + 1> devlink_port_fn_attr_cap_st
 
 std::string_view devlink_port_fn_attr_cap_str(devlink_port_fn_attr_cap value)
 {
-	if (value < 0 || value >= (int)(devlink_port_fn_attr_cap_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_port_fn_attr_cap_strmap.size())) {
 		return "";
 	}
 	return devlink_port_fn_attr_cap_strmap[value];
@@ -162,7 +162,7 @@ static constexpr std::array<std::string_view, 1 + 1> devlink_rate_type_strmap = 
 
 std::string_view devlink_rate_type_str(devlink_rate_type value)
 {
-	if (value < 0 || value >= (int)(devlink_rate_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_rate_type_strmap.size())) {
 		return "";
 	}
 	return devlink_rate_type_strmap[value];
@@ -177,7 +177,7 @@ static constexpr std::array<std::string_view, 1 + 1> devlink_sb_threshold_type_s
 
 std::string_view devlink_sb_threshold_type_str(devlink_sb_threshold_type value)
 {
-	if (value < 0 || value >= (int)(devlink_sb_threshold_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_sb_threshold_type_strmap.size())) {
 		return "";
 	}
 	return devlink_sb_threshold_type_strmap[value];
@@ -193,7 +193,7 @@ static constexpr std::array<std::string_view, 2 + 1> devlink_eswitch_mode_strmap
 
 std::string_view devlink_eswitch_mode_str(devlink_eswitch_mode value)
 {
-	if (value < 0 || value >= (int)(devlink_eswitch_mode_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_eswitch_mode_strmap.size())) {
 		return "";
 	}
 	return devlink_eswitch_mode_strmap[value];
@@ -211,7 +211,7 @@ static constexpr std::array<std::string_view, 3 + 1> devlink_eswitch_inline_mode
 std::string_view
 devlink_eswitch_inline_mode_str(devlink_eswitch_inline_mode value)
 {
-	if (value < 0 || value >= (int)(devlink_eswitch_inline_mode_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_eswitch_inline_mode_strmap.size())) {
 		return "";
 	}
 	return devlink_eswitch_inline_mode_strmap[value];
@@ -227,7 +227,7 @@ static constexpr std::array<std::string_view, 1 + 1> devlink_eswitch_encap_mode_
 std::string_view
 devlink_eswitch_encap_mode_str(devlink_eswitch_encap_mode value)
 {
-	if (value < 0 || value >= (int)(devlink_eswitch_encap_mode_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_eswitch_encap_mode_strmap.size())) {
 		return "";
 	}
 	return devlink_eswitch_encap_mode_strmap[value];
@@ -243,7 +243,7 @@ static constexpr std::array<std::string_view, 2 + 1> devlink_dpipe_header_id_str
 
 std::string_view devlink_dpipe_header_id_str(devlink_dpipe_header_id value)
 {
-	if (value < 0 || value >= (int)(devlink_dpipe_header_id_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_dpipe_header_id_strmap.size())) {
 		return "";
 	}
 	return devlink_dpipe_header_id_strmap[value];
@@ -257,7 +257,7 @@ static constexpr std::array<std::string_view, 0 + 1> devlink_dpipe_match_type_st
 
 std::string_view devlink_dpipe_match_type_str(devlink_dpipe_match_type value)
 {
-	if (value < 0 || value >= (int)(devlink_dpipe_match_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_dpipe_match_type_strmap.size())) {
 		return "";
 	}
 	return devlink_dpipe_match_type_strmap[value];
@@ -271,7 +271,7 @@ static constexpr std::array<std::string_view, 0 + 1> devlink_dpipe_action_type_s
 
 std::string_view devlink_dpipe_action_type_str(devlink_dpipe_action_type value)
 {
-	if (value < 0 || value >= (int)(devlink_dpipe_action_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_dpipe_action_type_strmap.size())) {
 		return "";
 	}
 	return devlink_dpipe_action_type_strmap[value];
@@ -287,7 +287,7 @@ static constexpr std::array<std::string_view, 1 + 1> devlink_dpipe_field_mapping
 std::string_view
 devlink_dpipe_field_mapping_type_str(devlink_dpipe_field_mapping_type value)
 {
-	if (value < 0 || value >= (int)(devlink_dpipe_field_mapping_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_dpipe_field_mapping_type_strmap.size())) {
 		return "";
 	}
 	return devlink_dpipe_field_mapping_type_strmap[value];
@@ -301,7 +301,7 @@ static constexpr std::array<std::string_view, 0 + 1> devlink_resource_unit_strma
 
 std::string_view devlink_resource_unit_str(devlink_resource_unit value)
 {
-	if (value < 0 || value >= (int)(devlink_resource_unit_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_resource_unit_strmap.size())) {
 		return "";
 	}
 	return devlink_resource_unit_strmap[value];
@@ -316,7 +316,7 @@ static constexpr std::array<std::string_view, 1 + 1> devlink_resource_scope_strm
 
 std::string_view devlink_resource_scope_str(devlink_resource_scope value)
 {
-	if (value < 0 || value >= (int)(devlink_resource_scope_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_resource_scope_strmap.size())) {
 		return "";
 	}
 	return devlink_resource_scope_strmap[value];
@@ -331,7 +331,7 @@ static constexpr std::array<std::string_view, 2 + 1> devlink_reload_action_strma
 
 std::string_view devlink_reload_action_str(devlink_reload_action value)
 {
-	if (value < 0 || value >= (int)(devlink_reload_action_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_reload_action_strmap.size())) {
 		return "";
 	}
 	return devlink_reload_action_strmap[value];
@@ -347,7 +347,7 @@ static constexpr std::array<std::string_view, 2 + 1> devlink_param_cmode_strmap 
 
 std::string_view devlink_param_cmode_str(devlink_param_cmode value)
 {
-	if (value < 0 || value >= (int)(devlink_param_cmode_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_param_cmode_strmap.size())) {
 		return "";
 	}
 	return devlink_param_cmode_strmap[value];
@@ -362,7 +362,7 @@ static constexpr std::array<std::string_view, 1 + 1> devlink_flash_overwrite_str
 
 std::string_view devlink_flash_overwrite_str(devlink_flash_overwrite value)
 {
-	if (value < 0 || value >= (int)(devlink_flash_overwrite_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_flash_overwrite_strmap.size())) {
 		return "";
 	}
 	return devlink_flash_overwrite_strmap[value];
@@ -378,7 +378,7 @@ static constexpr std::array<std::string_view, 2 + 1> devlink_trap_action_strmap 
 
 std::string_view devlink_trap_action_str(devlink_trap_action value)
 {
-	if (value < 0 || value >= (int)(devlink_trap_action_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_trap_action_strmap.size())) {
 		return "";
 	}
 	return devlink_trap_action_strmap[value];
@@ -394,7 +394,7 @@ static constexpr std::array<std::string_view, 2 + 1> devlink_trap_type_strmap = 
 
 std::string_view devlink_trap_type_str(devlink_trap_type value)
 {
-	if (value < 0 || value >= (int)(devlink_trap_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_trap_type_strmap.size())) {
 		return "";
 	}
 	return devlink_trap_type_strmap[value];
@@ -415,7 +415,7 @@ static constexpr std::array<std::string_view, 11 + 1> devlink_var_attr_type_strm
 
 std::string_view devlink_var_attr_type_str(devlink_var_attr_type value)
 {
-	if (value < 0 || value >= (int)(devlink_var_attr_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(devlink_var_attr_type_strmap.size())) {
 		return "";
 	}
 	return devlink_var_attr_type_strmap[value];

--- a/generated/dpll-user.cpp
+++ b/generated/dpll-user.cpp
@@ -33,7 +33,7 @@ static constexpr std::array<std::string_view, DPLL_CMD_PIN_CHANGE_NTF + 1> dpll_
 
 std::string_view dpll_op_str(int op)
 {
-	if (op < 0 || op >= (int)(dpll_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(dpll_op_strmap.size())) {
 		return "";
 	}
 	return dpll_op_strmap[op];
@@ -48,7 +48,7 @@ static constexpr std::array<std::string_view, 2 + 1> dpll_mode_strmap = []() {
 
 std::string_view dpll_mode_str(dpll_mode value)
 {
-	if (value < 0 || value >= (int)(dpll_mode_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(dpll_mode_strmap.size())) {
 		return "";
 	}
 	return dpll_mode_strmap[value];
@@ -65,7 +65,7 @@ static constexpr std::array<std::string_view, 4 + 1> dpll_lock_status_strmap = [
 
 std::string_view dpll_lock_status_str(dpll_lock_status value)
 {
-	if (value < 0 || value >= (int)(dpll_lock_status_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(dpll_lock_status_strmap.size())) {
 		return "";
 	}
 	return dpll_lock_status_strmap[value];
@@ -82,7 +82,7 @@ static constexpr std::array<std::string_view, 4 + 1> dpll_lock_status_error_strm
 
 std::string_view dpll_lock_status_error_str(dpll_lock_status_error value)
 {
-	if (value < 0 || value >= (int)(dpll_lock_status_error_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(dpll_lock_status_error_strmap.size())) {
 		return "";
 	}
 	return dpll_lock_status_error_strmap[value];
@@ -103,7 +103,7 @@ static constexpr std::array<std::string_view, 8 + 1> dpll_clock_quality_level_st
 
 std::string_view dpll_clock_quality_level_str(dpll_clock_quality_level value)
 {
-	if (value < 0 || value >= (int)(dpll_clock_quality_level_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(dpll_clock_quality_level_strmap.size())) {
 		return "";
 	}
 	return dpll_clock_quality_level_strmap[value];
@@ -118,7 +118,7 @@ static constexpr std::array<std::string_view, 2 + 1> dpll_type_strmap = []() {
 
 std::string_view dpll_type_str(dpll_type value)
 {
-	if (value < 0 || value >= (int)(dpll_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(dpll_type_strmap.size())) {
 		return "";
 	}
 	return dpll_type_strmap[value];
@@ -136,7 +136,7 @@ static constexpr std::array<std::string_view, 5 + 1> dpll_pin_type_strmap = []()
 
 std::string_view dpll_pin_type_str(dpll_pin_type value)
 {
-	if (value < 0 || value >= (int)(dpll_pin_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(dpll_pin_type_strmap.size())) {
 		return "";
 	}
 	return dpll_pin_type_strmap[value];
@@ -151,7 +151,7 @@ static constexpr std::array<std::string_view, 2 + 1> dpll_pin_direction_strmap =
 
 std::string_view dpll_pin_direction_str(dpll_pin_direction value)
 {
-	if (value < 0 || value >= (int)(dpll_pin_direction_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(dpll_pin_direction_strmap.size())) {
 		return "";
 	}
 	return dpll_pin_direction_strmap[value];
@@ -167,7 +167,7 @@ static constexpr std::array<std::string_view, 3 + 1> dpll_pin_state_strmap = [](
 
 std::string_view dpll_pin_state_str(dpll_pin_state value)
 {
-	if (value < 0 || value >= (int)(dpll_pin_state_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(dpll_pin_state_strmap.size())) {
 		return "";
 	}
 	return dpll_pin_state_strmap[value];
@@ -184,7 +184,7 @@ static constexpr std::array<std::string_view, 2 + 1> dpll_pin_capabilities_strma
 std::string_view dpll_pin_capabilities_str(dpll_pin_capabilities value)
 {
 	value = (dpll_pin_capabilities)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(dpll_pin_capabilities_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(dpll_pin_capabilities_strmap.size())) {
 		return "";
 	}
 	return dpll_pin_capabilities_strmap[value];
@@ -199,7 +199,7 @@ static constexpr std::array<std::string_view, 1 + 1> dpll_feature_state_strmap =
 
 std::string_view dpll_feature_state_str(dpll_feature_state value)
 {
-	if (value < 0 || value >= (int)(dpll_feature_state_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(dpll_feature_state_strmap.size())) {
 		return "";
 	}
 	return dpll_feature_state_strmap[value];

--- a/generated/ethtool-user.cpp
+++ b/generated/ethtool-user.cpp
@@ -76,7 +76,7 @@ static constexpr std::array<std::string_view, 54 + 1> ethtool_op_strmap = []() {
 
 std::string_view ethtool_op_str(int op)
 {
-	if (op < 0 || op >= (int)(ethtool_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(ethtool_op_strmap.size())) {
 		return "";
 	}
 	return ethtool_op_strmap[op];
@@ -92,7 +92,7 @@ static constexpr std::array<std::string_view, 2 + 1> ethtool_udp_tunnel_type_str
 
 std::string_view ethtool_udp_tunnel_type_str(int value)
 {
-	if (value < 0 || value >= (int)(ethtool_udp_tunnel_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ethtool_udp_tunnel_type_strmap.size())) {
 		return "";
 	}
 	return ethtool_udp_tunnel_type_strmap[value];
@@ -105,7 +105,7 @@ static constexpr std::array<std::string_view, 0 + 1> ethtool_stringset_strmap = 
 
 std::string_view ethtool_stringset_str(ethtool_stringset value)
 {
-	if (value < 0 || value >= (int)(ethtool_stringset_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ethtool_stringset_strmap.size())) {
 		return "";
 	}
 	return ethtool_stringset_strmap[value];
@@ -122,7 +122,7 @@ static constexpr std::array<std::string_view, 2 + 1> ethtool_header_flags_strmap
 std::string_view ethtool_header_flags_str(ethtool_header_flags value)
 {
 	value = (ethtool_header_flags)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(ethtool_header_flags_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ethtool_header_flags_strmap.size())) {
 		return "";
 	}
 	return ethtool_header_flags_strmap[value];
@@ -140,7 +140,7 @@ static constexpr std::array<std::string_view, 3 + 1> ethtool_module_fw_flash_sta
 std::string_view
 ethtool_module_fw_flash_status_str(ethtool_module_fw_flash_status value)
 {
-	if (value < 0 || value >= (int)(ethtool_module_fw_flash_status_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ethtool_module_fw_flash_status_strmap.size())) {
 		return "";
 	}
 	return ethtool_module_fw_flash_status_strmap[value];
@@ -162,7 +162,7 @@ static constexpr std::array<std::string_view, 8 + 1> ethtool_c33_pse_ext_state_s
 
 std::string_view ethtool_c33_pse_ext_state_str(ethtool_c33_pse_ext_state value)
 {
-	if (value < 0 || value >= (int)(ethtool_c33_pse_ext_state_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ethtool_c33_pse_ext_state_strmap.size())) {
 		return "";
 	}
 	return ethtool_c33_pse_ext_state_strmap[value];
@@ -177,7 +177,7 @@ static constexpr std::array<std::string_view, 1 + 1> ethtool_phy_upstream_type_s
 
 std::string_view ethtool_phy_upstream_type_str(phy_upstream value)
 {
-	if (value < 0 || value >= (int)(ethtool_phy_upstream_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ethtool_phy_upstream_type_strmap.size())) {
 		return "";
 	}
 	return ethtool_phy_upstream_type_strmap[value];
@@ -193,7 +193,7 @@ static constexpr std::array<std::string_view, 2 + 1> ethtool_tcp_data_split_strm
 
 std::string_view ethtool_tcp_data_split_str(ethtool_tcp_data_split value)
 {
-	if (value < 0 || value >= (int)(ethtool_tcp_data_split_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ethtool_tcp_data_split_strmap.size())) {
 		return "";
 	}
 	return ethtool_tcp_data_split_strmap[value];
@@ -208,7 +208,7 @@ static constexpr std::array<std::string_view, 2 + 1> ethtool_hwtstamp_source_str
 
 std::string_view ethtool_hwtstamp_source_str(hwtstamp_source value)
 {
-	if (value < 0 || value >= (int)(ethtool_hwtstamp_source_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ethtool_hwtstamp_source_strmap.size())) {
 		return "";
 	}
 	return ethtool_hwtstamp_source_strmap[value];
@@ -229,7 +229,7 @@ static constexpr std::array<std::string_view, 6 + 1> ethtool_pse_event_strmap = 
 std::string_view ethtool_pse_event_str(ethtool_pse_event value)
 {
 	value = (ethtool_pse_event)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(ethtool_pse_event_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ethtool_pse_event_strmap.size())) {
 		return "";
 	}
 	return ethtool_pse_event_strmap[value];
@@ -245,7 +245,7 @@ static constexpr std::array<std::string_view, 1 + 1> ethtool_input_xfrm_strmap =
 std::string_view ethtool_input_xfrm_str(int value)
 {
 	value = (int)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(ethtool_input_xfrm_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ethtool_input_xfrm_strmap.size())) {
 		return "";
 	}
 	return ethtool_input_xfrm_strmap[value];
@@ -269,7 +269,7 @@ static constexpr std::array<std::string_view, 31 + 1> ethtool_rxfh_fields_strmap
 std::string_view ethtool_rxfh_fields_str(int value)
 {
 	value = (int)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(ethtool_rxfh_fields_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ethtool_rxfh_fields_strmap.size())) {
 		return "";
 	}
 	return ethtool_rxfh_fields_strmap[value];

--- a/generated/fou-user.cpp
+++ b/generated/fou-user.cpp
@@ -24,7 +24,7 @@ static constexpr std::array<std::string_view, FOU_CMD_GET + 1> fou_op_strmap = [
 
 std::string_view fou_op_str(int op)
 {
-	if (op < 0 || op >= (int)(fou_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(fou_op_strmap.size())) {
 		return "";
 	}
 	return fou_op_strmap[op];
@@ -40,7 +40,7 @@ static constexpr std::array<std::string_view, 2 + 1> fou_encap_type_strmap = [](
 
 std::string_view fou_encap_type_str(int value)
 {
-	if (value < 0 || value >= (int)(fou_encap_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(fou_encap_type_strmap.size())) {
 		return "";
 	}
 	return fou_encap_type_strmap[value];

--- a/generated/handshake-user.cpp
+++ b/generated/handshake-user.cpp
@@ -24,7 +24,7 @@ static constexpr std::array<std::string_view, HANDSHAKE_CMD_DONE + 1> handshake_
 
 std::string_view handshake_op_str(int op)
 {
-	if (op < 0 || op >= (int)(handshake_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(handshake_op_strmap.size())) {
 		return "";
 	}
 	return handshake_op_strmap[op];
@@ -40,7 +40,7 @@ static constexpr std::array<std::string_view, 2 + 1> handshake_handler_class_str
 
 std::string_view handshake_handler_class_str(handshake_handler_class value)
 {
-	if (value < 0 || value >= (int)(handshake_handler_class_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(handshake_handler_class_strmap.size())) {
 		return "";
 	}
 	return handshake_handler_class_strmap[value];
@@ -56,7 +56,7 @@ static constexpr std::array<std::string_view, 2 + 1> handshake_msg_type_strmap =
 
 std::string_view handshake_msg_type_str(handshake_msg_type value)
 {
-	if (value < 0 || value >= (int)(handshake_msg_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(handshake_msg_type_strmap.size())) {
 		return "";
 	}
 	return handshake_msg_type_strmap[value];
@@ -73,7 +73,7 @@ static constexpr std::array<std::string_view, 3 + 1> handshake_auth_strmap = [](
 
 std::string_view handshake_auth_str(handshake_auth value)
 {
-	if (value < 0 || value >= (int)(handshake_auth_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(handshake_auth_strmap.size())) {
 		return "";
 	}
 	return handshake_auth_strmap[value];

--- a/generated/lockd-user.cpp
+++ b/generated/lockd-user.cpp
@@ -23,7 +23,7 @@ static constexpr std::array<std::string_view, LOCKD_CMD_SERVER_GET + 1> lockd_op
 
 std::string_view lockd_op_str(int op)
 {
-	if (op < 0 || op >= (int)(lockd_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(lockd_op_strmap.size())) {
 		return "";
 	}
 	return lockd_op_strmap[op];

--- a/generated/mptcp_pm-user.cpp
+++ b/generated/mptcp_pm-user.cpp
@@ -32,7 +32,7 @@ static constexpr std::array<std::string_view, MPTCP_PM_CMD_SUBFLOW_DESTROY + 1> 
 
 std::string_view mptcp_pm_op_str(int op)
 {
-	if (op < 0 || op >= (int)(mptcp_pm_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(mptcp_pm_op_strmap.size())) {
 		return "";
 	}
 	return mptcp_pm_op_strmap[op];
@@ -56,7 +56,7 @@ static constexpr std::array<std::string_view, 16 + 1> mptcp_pm_event_type_strmap
 
 std::string_view mptcp_pm_event_type_str(mptcp_event_type value)
 {
-	if (value < 0 || value >= (int)(mptcp_pm_event_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(mptcp_pm_event_type_strmap.size())) {
 		return "";
 	}
 	return mptcp_pm_event_type_strmap[value];

--- a/generated/net_shaper-user.cpp
+++ b/generated/net_shaper-user.cpp
@@ -26,7 +26,7 @@ static constexpr std::array<std::string_view, NET_SHAPER_CMD_CAP_GET + 1> net_sh
 
 std::string_view net_shaper_op_str(int op)
 {
-	if (op < 0 || op >= (int)(net_shaper_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(net_shaper_op_strmap.size())) {
 		return "";
 	}
 	return net_shaper_op_strmap[op];
@@ -43,7 +43,7 @@ static constexpr std::array<std::string_view, 3 + 1> net_shaper_scope_strmap = [
 
 std::string_view net_shaper_scope_str(net_shaper_scope value)
 {
-	if (value < 0 || value >= (int)(net_shaper_scope_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(net_shaper_scope_strmap.size())) {
 		return "";
 	}
 	return net_shaper_scope_strmap[value];
@@ -58,7 +58,7 @@ static constexpr std::array<std::string_view, 1 + 1> net_shaper_metric_strmap = 
 
 std::string_view net_shaper_metric_str(net_shaper_metric value)
 {
-	if (value < 0 || value >= (int)(net_shaper_metric_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(net_shaper_metric_strmap.size())) {
 		return "";
 	}
 	return net_shaper_metric_strmap[value];

--- a/generated/netdev-user.cpp
+++ b/generated/netdev-user.cpp
@@ -37,7 +37,7 @@ static constexpr std::array<std::string_view, NETDEV_CMD_QUEUE_CREATE + 1> netde
 
 std::string_view netdev_op_str(int op)
 {
-	if (op < 0 || op >= (int)(netdev_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(netdev_op_strmap.size())) {
 		return "";
 	}
 	return netdev_op_strmap[op];
@@ -58,7 +58,7 @@ static constexpr std::array<std::string_view, 6 + 1> netdev_xdp_act_strmap = [](
 std::string_view netdev_xdp_act_str(netdev_xdp_act value)
 {
 	value = (netdev_xdp_act)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(netdev_xdp_act_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(netdev_xdp_act_strmap.size())) {
 		return "";
 	}
 	return netdev_xdp_act_strmap[value];
@@ -75,7 +75,7 @@ static constexpr std::array<std::string_view, 2 + 1> netdev_xdp_rx_metadata_strm
 std::string_view netdev_xdp_rx_metadata_str(netdev_xdp_rx_metadata value)
 {
 	value = (netdev_xdp_rx_metadata)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(netdev_xdp_rx_metadata_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(netdev_xdp_rx_metadata_strmap.size())) {
 		return "";
 	}
 	return netdev_xdp_rx_metadata_strmap[value];
@@ -92,7 +92,7 @@ static constexpr std::array<std::string_view, 2 + 1> netdev_xsk_flags_strmap = [
 std::string_view netdev_xsk_flags_str(netdev_xsk_flags value)
 {
 	value = (netdev_xsk_flags)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(netdev_xsk_flags_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(netdev_xsk_flags_strmap.size())) {
 		return "";
 	}
 	return netdev_xsk_flags_strmap[value];
@@ -107,7 +107,7 @@ static constexpr std::array<std::string_view, 1 + 1> netdev_queue_type_strmap = 
 
 std::string_view netdev_queue_type_str(netdev_queue_type value)
 {
-	if (value < 0 || value >= (int)(netdev_queue_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(netdev_queue_type_strmap.size())) {
 		return "";
 	}
 	return netdev_queue_type_strmap[value];
@@ -122,7 +122,7 @@ static constexpr std::array<std::string_view, 0 + 1> netdev_qstats_scope_strmap 
 std::string_view netdev_qstats_scope_str(netdev_qstats_scope value)
 {
 	value = (netdev_qstats_scope)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(netdev_qstats_scope_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(netdev_qstats_scope_strmap.size())) {
 		return "";
 	}
 	return netdev_qstats_scope_strmap[value];
@@ -138,7 +138,7 @@ static constexpr std::array<std::string_view, 2 + 1> netdev_napi_threaded_strmap
 
 std::string_view netdev_napi_threaded_str(netdev_napi_threaded value)
 {
-	if (value < 0 || value >= (int)(netdev_napi_threaded_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(netdev_napi_threaded_strmap.size())) {
 		return "";
 	}
 	return netdev_napi_threaded_strmap[value];

--- a/generated/nfsd-user.cpp
+++ b/generated/nfsd-user.cpp
@@ -30,7 +30,7 @@ static constexpr std::array<std::string_view, NFSD_CMD_POOL_MODE_GET + 1> nfsd_o
 
 std::string_view nfsd_op_str(int op)
 {
-	if (op < 0 || op >= (int)(nfsd_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(nfsd_op_strmap.size())) {
 		return "";
 	}
 	return nfsd_op_strmap[op];

--- a/generated/nl80211-user.cpp
+++ b/generated/nl80211-user.cpp
@@ -24,7 +24,7 @@ static constexpr std::array<std::string_view, NL80211_CMD_GET_PROTOCOL_FEATURES 
 
 std::string_view nl80211_op_str(int op)
 {
-	if (op < 0 || op >= (int)(nl80211_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(nl80211_op_strmap.size())) {
 		return "";
 	}
 	return nl80211_op_strmap[op];
@@ -193,7 +193,7 @@ static constexpr std::array<std::string_view, 155 + 1> nl80211_commands_strmap =
 
 std::string_view nl80211_commands_str(nl80211_commands value)
 {
-	if (value < 0 || value >= (int)(nl80211_commands_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(nl80211_commands_strmap.size())) {
 		return "";
 	}
 	return nl80211_commands_strmap[value];
@@ -239,7 +239,7 @@ static constexpr std::array<std::string_view, 31 + 1> nl80211_feature_flags_strm
 std::string_view nl80211_feature_flags_str(nl80211_feature_flags value)
 {
 	value = (nl80211_feature_flags)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(nl80211_feature_flags_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(nl80211_feature_flags_strmap.size())) {
 		return "";
 	}
 	return nl80211_feature_flags_strmap[value];
@@ -256,7 +256,7 @@ static constexpr std::array<std::string_view, 3 + 1> nl80211_channel_type_strmap
 
 std::string_view nl80211_channel_type_str(nl80211_channel_type value)
 {
-	if (value < 0 || value >= (int)(nl80211_channel_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(nl80211_channel_type_strmap.size())) {
 		return "";
 	}
 	return nl80211_channel_type_strmap[value];
@@ -271,7 +271,7 @@ static constexpr std::array<std::string_view, 0 + 1> nl80211_protocol_features_s
 std::string_view nl80211_protocol_features_str(nl80211_protocol_features value)
 {
 	value = (nl80211_protocol_features)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(nl80211_protocol_features_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(nl80211_protocol_features_strmap.size())) {
 		return "";
 	}
 	return nl80211_protocol_features_strmap[value];

--- a/generated/nlctrl-user.cpp
+++ b/generated/nlctrl-user.cpp
@@ -23,7 +23,7 @@ static constexpr std::array<std::string_view, CTRL_CMD_GETPOLICY + 1> nlctrl_op_
 
 std::string_view nlctrl_op_str(int op)
 {
-	if (op < 0 || op >= (int)(nlctrl_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(nlctrl_op_strmap.size())) {
 		return "";
 	}
 	return nlctrl_op_strmap[op];
@@ -42,7 +42,7 @@ static constexpr std::array<std::string_view, 4 + 1> nlctrl_op_flags_strmap = []
 std::string_view nlctrl_op_flags_str(int value)
 {
 	value = (int)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(nlctrl_op_flags_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(nlctrl_op_flags_strmap.size())) {
 		return "";
 	}
 	return nlctrl_op_flags_strmap[value];
@@ -73,7 +73,7 @@ static constexpr std::array<std::string_view, 17 + 1> nlctrl_attr_type_strmap = 
 
 std::string_view nlctrl_attr_type_str(netlink_attribute_type value)
 {
-	if (value < 0 || value >= (int)(nlctrl_attr_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(nlctrl_attr_type_strmap.size())) {
 		return "";
 	}
 	return nlctrl_attr_type_strmap[value];

--- a/generated/ovpn-user.cpp
+++ b/generated/ovpn-user.cpp
@@ -32,7 +32,7 @@ static constexpr std::array<std::string_view, OVPN_CMD_PEER_FLOAT_NTF + 1> ovpn_
 
 std::string_view ovpn_op_str(int op)
 {
-	if (op < 0 || op >= (int)(ovpn_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(ovpn_op_strmap.size())) {
 		return "";
 	}
 	return ovpn_op_strmap[op];
@@ -48,7 +48,7 @@ static constexpr std::array<std::string_view, 2 + 1> ovpn_cipher_alg_strmap = []
 
 std::string_view ovpn_cipher_alg_str(ovpn_cipher_alg value)
 {
-	if (value < 0 || value >= (int)(ovpn_cipher_alg_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ovpn_cipher_alg_strmap.size())) {
 		return "";
 	}
 	return ovpn_cipher_alg_strmap[value];
@@ -66,7 +66,7 @@ static constexpr std::array<std::string_view, 4 + 1> ovpn_del_peer_reason_strmap
 
 std::string_view ovpn_del_peer_reason_str(ovpn_del_peer_reason value)
 {
-	if (value < 0 || value >= (int)(ovpn_del_peer_reason_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ovpn_del_peer_reason_strmap.size())) {
 		return "";
 	}
 	return ovpn_del_peer_reason_strmap[value];
@@ -81,7 +81,7 @@ static constexpr std::array<std::string_view, 1 + 1> ovpn_key_slot_strmap = []()
 
 std::string_view ovpn_key_slot_str(ovpn_key_slot value)
 {
-	if (value < 0 || value >= (int)(ovpn_key_slot_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ovpn_key_slot_strmap.size())) {
 		return "";
 	}
 	return ovpn_key_slot_strmap[value];

--- a/generated/ovs_datapath-user.cpp
+++ b/generated/ovs_datapath-user.cpp
@@ -24,7 +24,7 @@ static constexpr std::array<std::string_view, OVS_DP_CMD_GET + 1> ovs_datapath_o
 
 std::string_view ovs_datapath_op_str(int op)
 {
-	if (op < 0 || op >= (int)(ovs_datapath_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(ovs_datapath_op_strmap.size())) {
 		return "";
 	}
 	return ovs_datapath_op_strmap[op];
@@ -42,7 +42,7 @@ static constexpr std::array<std::string_view, 3 + 1> ovs_datapath_user_features_
 std::string_view ovs_datapath_user_features_str(int value)
 {
 	value = (int)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(ovs_datapath_user_features_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ovs_datapath_user_features_strmap.size())) {
 		return "";
 	}
 	return ovs_datapath_user_features_strmap[value];

--- a/generated/ovs_flow-user.cpp
+++ b/generated/ovs_flow-user.cpp
@@ -23,7 +23,7 @@ static constexpr std::array<std::string_view, OVS_FLOW_CMD_GET + 1> ovs_flow_op_
 
 std::string_view ovs_flow_op_str(int op)
 {
-	if (op < 0 || op >= (int)(ovs_flow_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(ovs_flow_op_strmap.size())) {
 		return "";
 	}
 	return ovs_flow_op_strmap[op];
@@ -40,7 +40,7 @@ static constexpr std::array<std::string_view, 255 + 1> ovs_flow_ovs_frag_type_st
 
 std::string_view ovs_flow_ovs_frag_type_str(ovs_frag_type value)
 {
-	if (value < 0 || value >= (int)(ovs_flow_ovs_frag_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ovs_flow_ovs_frag_type_strmap.size())) {
 		return "";
 	}
 	return ovs_flow_ovs_frag_type_strmap[value];
@@ -57,7 +57,7 @@ static constexpr std::array<std::string_view, 2 + 1> ovs_flow_ovs_ufid_flags_str
 std::string_view ovs_flow_ovs_ufid_flags_str(int value)
 {
 	value = (int)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(ovs_flow_ovs_ufid_flags_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ovs_flow_ovs_ufid_flags_strmap.size())) {
 		return "";
 	}
 	return ovs_flow_ovs_ufid_flags_strmap[value];
@@ -71,7 +71,7 @@ static constexpr std::array<std::string_view, 0 + 1> ovs_flow_ovs_hash_alg_strma
 
 std::string_view ovs_flow_ovs_hash_alg_str(ovs_hash_alg value)
 {
-	if (value < 0 || value >= (int)(ovs_flow_ovs_hash_alg_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ovs_flow_ovs_hash_alg_strmap.size())) {
 		return "";
 	}
 	return ovs_flow_ovs_hash_alg_strmap[value];
@@ -93,7 +93,7 @@ static constexpr std::array<std::string_view, 7 + 1> ovs_flow_ct_state_flags_str
 std::string_view ovs_flow_ct_state_flags_str(int value)
 {
 	value = (int)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(ovs_flow_ct_state_flags_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ovs_flow_ct_state_flags_strmap.size())) {
 		return "";
 	}
 	return ovs_flow_ct_state_flags_strmap[value];

--- a/generated/ovs_vport-user.cpp
+++ b/generated/ovs_vport-user.cpp
@@ -24,7 +24,7 @@ static constexpr std::array<std::string_view, OVS_VPORT_CMD_GET + 1> ovs_vport_o
 
 std::string_view ovs_vport_op_str(int op)
 {
-	if (op < 0 || op >= (int)(ovs_vport_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(ovs_vport_op_strmap.size())) {
 		return "";
 	}
 	return ovs_vport_op_strmap[op];
@@ -43,7 +43,7 @@ static constexpr std::array<std::string_view, 5 + 1> ovs_vport_vport_type_strmap
 
 std::string_view ovs_vport_vport_type_str(ovs_vport_type value)
 {
-	if (value < 0 || value >= (int)(ovs_vport_vport_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(ovs_vport_vport_type_strmap.size())) {
 		return "";
 	}
 	return ovs_vport_vport_type_strmap[value];

--- a/generated/psp-user.cpp
+++ b/generated/psp-user.cpp
@@ -31,7 +31,7 @@ static constexpr std::array<std::string_view, PSP_CMD_GET_STATS + 1> psp_op_strm
 
 std::string_view psp_op_str(int op)
 {
-	if (op < 0 || op >= (int)(psp_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(psp_op_strmap.size())) {
 		return "";
 	}
 	return psp_op_strmap[op];
@@ -48,7 +48,7 @@ static constexpr std::array<std::string_view, 3 + 1> psp_version_strmap = []() {
 
 std::string_view psp_version_str(psp_version value)
 {
-	if (value < 0 || value >= (int)(psp_version_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(psp_version_strmap.size())) {
 		return "";
 	}
 	return psp_version_strmap[value];

--- a/generated/rt-addr-user.cpp
+++ b/generated/rt-addr-user.cpp
@@ -23,7 +23,7 @@ static constexpr std::array<std::string_view, RTM_GETMULTICAST + 1> rt_addr_op_s
 
 std::string_view rt_addr_op_str(int op)
 {
-	if (op < 0 || op >= (int)(rt_addr_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(rt_addr_op_strmap.size())) {
 		return "";
 	}
 	return rt_addr_op_strmap[op];
@@ -49,7 +49,7 @@ static constexpr std::array<std::string_view, 11 + 1> rt_addr_ifa_flags_strmap =
 std::string_view rt_addr_ifa_flags_str(int value)
 {
 	value = (int)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(rt_addr_ifa_flags_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_addr_ifa_flags_strmap.size())) {
 		return "";
 	}
 	return rt_addr_ifa_flags_strmap[value];

--- a/generated/rt-link-user.cpp
+++ b/generated/rt-link-user.cpp
@@ -27,7 +27,7 @@ static constexpr std::array<std::string_view, 92 + 1> rt_link_op_strmap = []() {
 
 std::string_view rt_link_op_str(int op)
 {
-	if (op < 0 || op >= (int)(rt_link_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(rt_link_op_strmap.size())) {
 		return "";
 	}
 	return rt_link_op_strmap[op];
@@ -60,7 +60,7 @@ static constexpr std::array<std::string_view, 18 + 1> rt_link_ifinfo_flags_strma
 std::string_view rt_link_ifinfo_flags_str(net_device_flags value)
 {
 	value = (net_device_flags)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(rt_link_ifinfo_flags_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_link_ifinfo_flags_strmap.size())) {
 		return "";
 	}
 	return rt_link_ifinfo_flags_strmap[value];
@@ -75,7 +75,7 @@ static constexpr std::array<std::string_view, 34984 + 1> rt_link_vlan_protocols_
 
 std::string_view rt_link_vlan_protocols_str(int value)
 {
-	if (value < 0 || value >= (int)(rt_link_vlan_protocols_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_link_vlan_protocols_strmap.size())) {
 		return "";
 	}
 	return rt_link_vlan_protocols_strmap[value];
@@ -121,7 +121,7 @@ static constexpr std::array<std::string_view, 32 + 1> rt_link_ipv4_devconf_strma
 
 std::string_view rt_link_ipv4_devconf_str(int value)
 {
-	if (value < 0 || value >= (int)(rt_link_ipv4_devconf_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_link_ipv4_devconf_strmap.size())) {
 		return "";
 	}
 	return rt_link_ipv4_devconf_strmap[value];
@@ -192,7 +192,7 @@ static constexpr std::array<std::string_view, 57 + 1> rt_link_ipv6_devconf_strma
 
 std::string_view rt_link_ipv6_devconf_str(int value)
 {
-	if (value < 0 || value >= (int)(rt_link_ipv6_devconf_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_link_ipv6_devconf_strmap.size())) {
 		return "";
 	}
 	return rt_link_ipv6_devconf_strmap[value];
@@ -212,7 +212,7 @@ static constexpr std::array<std::string_view, 6 + 1> rt_link_ifla_icmp6_stats_st
 
 std::string_view rt_link_ifla_icmp6_stats_str(int value)
 {
-	if (value < 0 || value >= (int)(rt_link_ifla_icmp6_stats_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_link_ifla_icmp6_stats_strmap.size())) {
 		return "";
 	}
 	return rt_link_ifla_icmp6_stats_strmap[value];
@@ -262,7 +262,7 @@ static constexpr std::array<std::string_view, 36 + 1> rt_link_ifla_inet6_stats_s
 
 std::string_view rt_link_ifla_inet6_stats_str(int value)
 {
-	if (value < 0 || value >= (int)(rt_link_ifla_inet6_stats_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_link_ifla_inet6_stats_strmap.size())) {
 		return "";
 	}
 	return rt_link_ifla_inet6_stats_strmap[value];
@@ -281,7 +281,7 @@ static constexpr std::array<std::string_view, 4 + 1> rt_link_vlan_flags_strmap =
 std::string_view rt_link_vlan_flags_str(int value)
 {
 	value = (int)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(rt_link_vlan_flags_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_link_vlan_flags_strmap.size())) {
 		return "";
 	}
 	return rt_link_vlan_flags_strmap[value];
@@ -297,7 +297,7 @@ static constexpr std::array<std::string_view, 2 + 1> rt_link_ifla_vf_link_state_
 
 std::string_view rt_link_ifla_vf_link_state_enum_str(int value)
 {
-	if (value < 0 || value >= (int)(rt_link_ifla_vf_link_state_enum_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_link_ifla_vf_link_state_enum_strmap.size())) {
 		return "";
 	}
 	return rt_link_ifla_vf_link_state_enum_strmap[value];
@@ -319,7 +319,7 @@ static constexpr std::array<std::string_view, 7 + 1> rt_link_rtext_filter_strmap
 std::string_view rt_link_rtext_filter_str(int value)
 {
 	value = (int)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(rt_link_rtext_filter_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_link_rtext_filter_strmap.size())) {
 		return "";
 	}
 	return rt_link_rtext_filter_strmap[value];
@@ -334,7 +334,7 @@ static constexpr std::array<std::string_view, 2 + 1> rt_link_netkit_policy_strma
 
 std::string_view rt_link_netkit_policy_str(int value)
 {
-	if (value < 0 || value >= (int)(rt_link_netkit_policy_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_link_netkit_policy_strmap.size())) {
 		return "";
 	}
 	return rt_link_netkit_policy_strmap[value];
@@ -349,7 +349,7 @@ static constexpr std::array<std::string_view, 1 + 1> rt_link_netkit_mode_strmap 
 
 std::string_view rt_link_netkit_mode_str(netkit_mode value)
 {
-	if (value < 0 || value >= (int)(rt_link_netkit_mode_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_link_netkit_mode_strmap.size())) {
 		return "";
 	}
 	return rt_link_netkit_mode_strmap[value];
@@ -364,7 +364,7 @@ static constexpr std::array<std::string_view, 1 + 1> rt_link_netkit_scrub_strmap
 
 std::string_view rt_link_netkit_scrub_str(int value)
 {
-	if (value < 0 || value >= (int)(rt_link_netkit_scrub_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_link_netkit_scrub_strmap.size())) {
 		return "";
 	}
 	return rt_link_netkit_scrub_strmap[value];
@@ -379,7 +379,7 @@ static constexpr std::array<std::string_view, 1 + 1> rt_link_netkit_pairing_strm
 
 std::string_view rt_link_netkit_pairing_str(netkit_pairing value)
 {
-	if (value < 0 || value >= (int)(rt_link_netkit_pairing_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_link_netkit_pairing_strmap.size())) {
 		return "";
 	}
 	return rt_link_netkit_pairing_strmap[value];
@@ -394,7 +394,7 @@ static constexpr std::array<std::string_view, 1 + 1> rt_link_ovpn_mode_strmap = 
 
 std::string_view rt_link_ovpn_mode_str(ovpn_mode value)
 {
-	if (value < 0 || value >= (int)(rt_link_ovpn_mode_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_link_ovpn_mode_strmap.size())) {
 		return "";
 	}
 	return rt_link_ovpn_mode_strmap[value];
@@ -410,7 +410,7 @@ static constexpr std::array<std::string_view, 2 + 1> rt_link_br_stp_mode_strmap 
 
 std::string_view rt_link_br_stp_mode_str(br_stp_mode value)
 {
-	if (value < 0 || value >= (int)(rt_link_br_stp_mode_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_link_br_stp_mode_strmap.size())) {
 		return "";
 	}
 	return rt_link_br_stp_mode_strmap[value];

--- a/generated/rt-neigh-user.cpp
+++ b/generated/rt-neigh-user.cpp
@@ -24,7 +24,7 @@ static constexpr std::array<std::string_view, 64 + 1> rt_neigh_op_strmap = []() 
 
 std::string_view rt_neigh_op_str(int op)
 {
-	if (op < 0 || op >= (int)(rt_neigh_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(rt_neigh_op_strmap.size())) {
 		return "";
 	}
 	return rt_neigh_op_strmap[op];
@@ -46,7 +46,7 @@ static constexpr std::array<std::string_view, 7 + 1> rt_neigh_nud_state_strmap =
 std::string_view rt_neigh_nud_state_str(int value)
 {
 	value = (int)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(rt_neigh_nud_state_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_neigh_nud_state_strmap.size())) {
 		return "";
 	}
 	return rt_neigh_nud_state_strmap[value];
@@ -68,7 +68,7 @@ static constexpr std::array<std::string_view, 7 + 1> rt_neigh_ntf_flags_strmap =
 std::string_view rt_neigh_ntf_flags_str(int value)
 {
 	value = (int)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(rt_neigh_ntf_flags_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_neigh_ntf_flags_strmap.size())) {
 		return "";
 	}
 	return rt_neigh_ntf_flags_strmap[value];
@@ -85,7 +85,7 @@ static constexpr std::array<std::string_view, 2 + 1> rt_neigh_ntf_ext_flags_strm
 std::string_view rt_neigh_ntf_ext_flags_str(int value)
 {
 	value = (int)(ffs(value) - 1);
-	if (value < 0 || value >= (int)(rt_neigh_ntf_ext_flags_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_neigh_ntf_ext_flags_strmap.size())) {
 		return "";
 	}
 	return rt_neigh_ntf_ext_flags_strmap[value];
@@ -110,7 +110,7 @@ static constexpr std::array<std::string_view, 11 + 1> rt_neigh_rtm_type_strmap =
 
 std::string_view rt_neigh_rtm_type_str(int value)
 {
-	if (value < 0 || value >= (int)(rt_neigh_rtm_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_neigh_rtm_type_strmap.size())) {
 		return "";
 	}
 	return rt_neigh_rtm_type_strmap[value];

--- a/generated/rt-route-user.cpp
+++ b/generated/rt-route-user.cpp
@@ -22,7 +22,7 @@ static constexpr std::array<std::string_view, 24 + 1> rt_route_op_strmap = []() 
 
 std::string_view rt_route_op_str(int op)
 {
-	if (op < 0 || op >= (int)(rt_route_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(rt_route_op_strmap.size())) {
 		return "";
 	}
 	return rt_route_op_strmap[op];
@@ -47,7 +47,7 @@ static constexpr std::array<std::string_view, 11 + 1> rt_route_rtm_type_strmap =
 
 std::string_view rt_route_rtm_type_str(int value)
 {
-	if (value < 0 || value >= (int)(rt_route_rtm_type_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_route_rtm_type_strmap.size())) {
 		return "";
 	}
 	return rt_route_rtm_type_strmap[value];

--- a/generated/rt-rule-user.cpp
+++ b/generated/rt-rule-user.cpp
@@ -23,7 +23,7 @@ static constexpr std::array<std::string_view, 33 + 1> rt_rule_op_strmap = []() {
 
 std::string_view rt_rule_op_str(int op)
 {
-	if (op < 0 || op >= (int)(rt_rule_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(rt_rule_op_strmap.size())) {
 		return "";
 	}
 	return rt_rule_op_strmap[op];
@@ -45,7 +45,7 @@ static constexpr std::array<std::string_view, 8 + 1> rt_rule_fr_act_strmap = [](
 
 std::string_view rt_rule_fr_act_str(int value)
 {
-	if (value < 0 || value >= (int)(rt_rule_fr_act_strmap.size())) {
+	if ((int)value < 0 || (int)value >= (int)(rt_rule_fr_act_strmap.size())) {
 		return "";
 	}
 	return rt_rule_fr_act_strmap[value];

--- a/generated/tcp_metrics-user.cpp
+++ b/generated/tcp_metrics-user.cpp
@@ -23,7 +23,7 @@ static constexpr std::array<std::string_view, TCP_METRICS_CMD_DEL + 1> tcp_metri
 
 std::string_view tcp_metrics_op_str(int op)
 {
-	if (op < 0 || op >= (int)(tcp_metrics_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(tcp_metrics_op_strmap.size())) {
 		return "";
 	}
 	return tcp_metrics_op_strmap[op];

--- a/generated/team-user.cpp
+++ b/generated/team-user.cpp
@@ -24,7 +24,7 @@ static constexpr std::array<std::string_view, TEAM_CMD_PORT_LIST_GET + 1> team_o
 
 std::string_view team_op_str(int op)
 {
-	if (op < 0 || op >= (int)(team_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(team_op_strmap.size())) {
 		return "";
 	}
 	return team_op_strmap[op];

--- a/ynl-gen-cpp.py
+++ b/ynl-gen-cpp.py
@@ -1902,7 +1902,7 @@ def _put_enum_to_str_helper(cw, render_name, map_name, arg_name, enum=None):
     cw.block_start()
     if enum and enum.type == "flags":
         cw.p(f"{arg_name} = ({enum.user_type})(ffs({arg_name}) - 1);")
-    cw.p(f"if ({arg_name} < 0 || {arg_name} >= (int)({map_name}.size()))")
+    cw.p(f"if ((int){arg_name} < 0 || (int){arg_name} >= (int)({map_name}.size()))")
     cw.p('return "";')
     cw.p(f"return {map_name}[{arg_name}];")
     cw.block_end()


### PR DESCRIPTION
The generated `<enum>_str` helpers compared the enum value directly against the strmap size. Clang's enum-range analysis treats the enum type as unable to hold values outside its declared range, making the `value >= N` (and `value < 0`) comparisons always-false — which trips `-Wtautological-compare`.

Cast the value to `int` in the generator so the defensive bounds check is preserved without the tautology. This lets consumers build with `-Wtautological-compare` enabled.

The generator (`ynl-gen-cpp.py`) is the only hand-edited change; all `generated/*-user.cpp` files were regenerated via `make -C generated` and are included for consistency with the committed generated tree.

Example of the generated change:

```c
-	if (op < 0 || op >= (int)(netdev_op_strmap.size())) {
+	if ((int)op < 0 || (int)op >= (int)(netdev_op_strmap.size())) {
```